### PR TITLE
Implemented support of delimiter options

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,7 +57,8 @@ init:
 install:
 - ps: |
       Execute-Action "installing tools" {
-          choco install codecov msbuild-sonarqube-runner opencover.portable
+          choco install codecov opencover.portable -y
+          dotnet tool install --global dotnet-sonarscanner
       }
 
 dotnet_csproj:
@@ -74,19 +75,10 @@ before_build:
 - ps: |
       Execute-Action "beginning code analysis" {
           if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-              # For security reasons, AppVeyor only exposes secure variables for pull requests from the same repositoy.
-              # If $env:SONARQUBE_GITHUB_TOKEN is not set, then it is a pull request from another repository and we'll
-              # skip SonarQube analysis.
-              if ($env:SONARQUBE_GITHUB_TOKEN) {
-                  MSBuild.SonarQube.Runner.exe begin /o:$env:SONARQUBE_ORGANIZATION /k:$env:APPVEYOR_PROJECT_NAME /v:$env:APPVEYOR_BUILD_VERSION /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=$env:SONARQUBE_TOKEN /d:sonar.cs.opencover.reportsPaths=coverage.xml /d:sonar.coverage.exclusions=**/*Tests.cs,**/*Tests.*.cs,**/*Mock.cs /d:sonar.github.pullRequest=$env:APPVEYOR_PULL_REQUEST_NUMBER /d:sonar.github.repository=$env:APPVEYOR_REPO_NAME /d:sonar.github.oauth=$env:SONARQUBE_GITHUB_TOKEN
-
-                  $env:SONARQUBE_RUNNING = $true
-              }
+              dotnet sonarscanner begin /o:$env:SONARQUBE_ORGANIZATION /k:$env:APPVEYOR_PROJECT_NAME /v:$env:APPVEYOR_BUILD_VERSION /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=$env:SONARQUBE_TOKEN /d:sonar.cs.opencover.reportsPaths=coverage.xml /d:sonar.coverage.exclusions=**/*Tests.cs /d:sonar.github.pullRequest=$env:APPVEYOR_PULL_REQUEST_NUMBER /d:sonar.github.repository=$env:APPVEYOR_REPO_NAME /d:sonar.github.oauth=$env:SONARQUBE_GITHUB_TOKEN
           }
           else {
-              MSBuild.SonarQube.Runner.exe begin /o:$env:SONARQUBE_ORGANIZATION /k:$env:APPVEYOR_PROJECT_NAME /v:$env:APPVEYOR_BUILD_VERSION /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=$env:SONARQUBE_TOKEN /d:sonar.cs.opencover.reportsPaths=coverage.xml /d:sonar.coverage.exclusions=**/*Tests.cs,**/*Tests.*.cs,**/*Mock.cs
-
-              $env:SONARQUBE_RUNNING = $true
+              dotnet sonarscanner begin /o:$env:SONARQUBE_ORGANIZATION /k:$env:APPVEYOR_PROJECT_NAME /v:$env:APPVEYOR_BUILD_VERSION /d:sonar.host.url=https://sonarcloud.io /d:sonar.login=$env:SONARQUBE_TOKEN /d:sonar.cs.opencover.reportsPaths=coverage.xml /d:sonar.coverage.exclusions=**/*Tests.cs
           }
       }
 
@@ -134,9 +126,7 @@ after_test:
 
 - ps: |
       Execute-Action "ending code analysis" {
-          if ($env:SONARQUBE_RUNNING -eq $true) {
-              MSBuild.SonarQube.Runner.exe end /d:sonar.login=$env:SONARQUBE_TOKEN
-          }
+          dotnet sonarscanner end /d:sonar.login=$env:SONARQUBE_TOKEN
       }
 
 artifacts:

--- a/src/PartialResponse.Core/DelimiterOptions.cs
+++ b/src/PartialResponse.Core/DelimiterOptions.cs
@@ -54,16 +54,16 @@ namespace PartialResponse.Core
         /// <summary>
         /// Gets default options for parser. Default options are:
         ///   field delimiters - ','
-        ///   nested field delimiters - '/', '.'
-        ///   field group start delimiters - '(', '['
-        ///   field group end delimiters - ')', ']'
+        ///   nested field delimiters - '/'
+        ///   field group start delimiters - '('
+        ///   field group end delimiters - ')'
         /// </summary>
         public static DelimiterOptions DefaultOptions
         {
             get
             {
                 return defaultOptions
-                    ?? (defaultOptions = new DelimiterOptions(new[] { ',' }, new[] { '/', '.' }, new[] { '(', '[' }, new[] { ')', ']' }));
+                    ?? (defaultOptions = new DelimiterOptions(new[] { ',' }, new[] { '/' }, new[] { '(' }, new[] { ')' }));
             }
         }
 

--- a/src/PartialResponse.Core/DelimiterOptions.cs
+++ b/src/PartialResponse.Core/DelimiterOptions.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace PartialResponse.Core
+{
+    /// <summary>
+    /// Represents delimiter options for parser
+    /// </summary>
+    public class DelimiterOptions
+    {
+        private static DelimiterOptions defaultOptions;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelimiterOptions"/> class.
+        /// </summary>
+        /// <param name="fieldsDelimiters">Characters representing field delimiters.</param>
+        /// <param name="nestedFieldDelimiters">Characters representing nested field delimiters.</param>
+        /// <param name="fieldGroupStartDelimiters">Characters representing field group start delimiters.</param>
+        /// <param name="fieldGroupEndDelimiters">Characters representing field group end delimiters.</param>
+        public DelimiterOptions(char[] fieldsDelimiters, char[] nestedFieldDelimiters, char[] fieldGroupStartDelimiters, char[] fieldGroupEndDelimiters)
+        {
+            var map = new Dictionary<char, TokenType>();
+
+            foreach (var c in fieldsDelimiters ?? throw new ArgumentNullException(nameof(fieldsDelimiters)))
+            {
+                map.Add(c, TokenType.FieldsDelimiter);
+            }
+
+            foreach (var c in nestedFieldDelimiters ?? throw new ArgumentNullException(nameof(nestedFieldDelimiters)))
+            {
+                map.Add(c, TokenType.NestedFieldDelimiter);
+            }
+
+            foreach (var c in fieldGroupStartDelimiters ?? throw new ArgumentNullException(nameof(fieldGroupStartDelimiters)))
+            {
+                map.Add(c, TokenType.FieldGroupStartDelimiter);
+            }
+
+            foreach (var c in fieldGroupEndDelimiters ?? throw new ArgumentNullException(nameof(fieldGroupEndDelimiters)))
+            {
+                map.Add(c, TokenType.FieldGroupEndDelimiter);
+            }
+
+            this.DelimiterToTokenTypeMap = map;
+
+            this.FieldsDelimiters = fieldsDelimiters;
+            this.NestedFieldDelimiters = nestedFieldDelimiters;
+            this.FieldGroupStartDelimiters = fieldGroupStartDelimiters;
+            this.FieldGroupEndDelimiters = fieldGroupEndDelimiters;
+        }
+
+        /// <summary>
+        /// Gets default options for parser. Default options are:
+        ///   field delimiters - ','
+        ///   nested field delimiters - '/', '.'
+        ///   field group start delimiters - '(', '['
+        ///   field group end delimiters - ')', ']'
+        /// </summary>
+        public static DelimiterOptions DefaultOptions
+        {
+            get
+            {
+                return defaultOptions
+                    ?? (defaultOptions = new DelimiterOptions(new[] { ',' }, new[] { '/', '.' }, new[] { '(', '[' }, new[] { ')', ']' }));
+            }
+        }
+
+        /// <summary>
+        /// Gets delimiter to token type map.
+        /// </summary>
+        public IReadOnlyDictionary<char, TokenType> DelimiterToTokenTypeMap { get; }
+
+        /// <summary>
+        /// Gets fields delimiters.
+        /// </summary>
+        public char[] FieldsDelimiters { get; }
+
+        /// <summary>
+        /// Gets nested field delimiters.
+        /// </summary>
+        public char[] NestedFieldDelimiters { get; }
+
+        /// <summary>
+        /// Gets nested field group start delimiters.
+        /// </summary>
+        public char[] FieldGroupStartDelimiters { get; }
+
+        /// <summary>
+        /// Gets nested field group end delimiters.
+        /// </summary>
+        public char[] FieldGroupEndDelimiters { get; }
+    }
+}

--- a/src/PartialResponse.Core/Field.cs
+++ b/src/PartialResponse.Core/Field.cs
@@ -1,6 +1,7 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
+using System.Linq;
 
 namespace PartialResponse.Core
 {
@@ -16,15 +17,20 @@ namespace PartialResponse.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="Field"/> structure.
         /// </summary>
-        /// <param name="value">The value of the field.</param>
-        public Field(string value)
+        /// <param name="parts">The value of the field.</param>
+        public Field(params string[] parts)
         {
-            if (value == null)
+            if (parts == null)
             {
-                throw new ArgumentNullException(nameof(value));
+                throw new ArgumentNullException(nameof(parts));
             }
 
-            this.Parts = value.Split('/');
+            if (parts.Length == 0 || parts.Any(string.IsNullOrEmpty))
+            {
+                throw new ArgumentException("Parts cannot be empty or null", nameof(parts));
+            }
+
+            this.Parts = parts;
         }
 
         /// <summary>
@@ -76,15 +82,6 @@ namespace PartialResponse.Core
             }
 
             return true;
-        }
-
-        /// <summary>
-        /// Returns a string that represents the current object.
-        /// </summary>
-        /// <returns>A string that represents the current object.</returns>
-        public override string ToString()
-        {
-            return string.Join("/", this.Parts);
         }
     }
 }

--- a/src/PartialResponse.Core/Fields.cs
+++ b/src/PartialResponse.Core/Fields.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+﻿// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -14,7 +14,7 @@ namespace PartialResponse.Core
     /// from your code.</remarks>
     public struct Fields
     {
-        private IEnumerable<Field> values;
+        private readonly IEnumerable<Field> values;
 
         private Fields(IEnumerable<Field> values)
         {
@@ -36,8 +36,10 @@ namespace PartialResponse.Core
         /// <param name="value">The value.</param>
         /// <param name="result">When this method returns, contains the <see cref="Fields"/> equivalent of the value,
         /// if the conversion succeeded, or null if the conversion failed.</param>
+        /// <param name="options">Optional options which allow to specify custom delimiters. If no value provided
+        /// a default options <see cref="DelimiterOptions.DefaultOptions"/> are used.</param>
         /// <returns>true if value was converted successfully; otherwise, false.</returns>
-        public static bool TryParse(string value, out Fields result)
+        public static bool TryParse(string value, out Fields result, DelimiterOptions options = null)
         {
             if (value == null)
             {
@@ -46,7 +48,7 @@ namespace PartialResponse.Core
 
             using (var reader = new StringReader(value))
             {
-                var context = new ParserContext(reader);
+                var context = new ParserContext(reader, options ?? DelimiterOptions.DefaultOptions);
                 var parser = new Parser(context);
 
                 parser.Parse();
@@ -68,10 +70,12 @@ namespace PartialResponse.Core
         /// Indicates whether a field matches the specified value.
         /// </summary>
         /// <param name="value">The value to match.</param>
+        /// <param name="delimiterOptions">Delimiter options to use when matching. If no options provided then the
+        /// default options <see cref="DelimiterOptions.DefaultOptions"/> are used.</param>
         /// <returns>true if a field matches the specified value; otherwise, false.</returns>
-        public bool Matches(string value)
+        public bool Matches(string value, DelimiterOptions delimiterOptions = null)
         {
-            return this.Matches(value, false);
+            return this.Matches(value, false, delimiterOptions);
         }
 
         /// <summary>
@@ -79,15 +83,23 @@ namespace PartialResponse.Core
         /// </summary>
         /// <param name="value">The value to match.</param>
         /// <param name="ignoreCase">A value which indicates whether matching should be case-insensitive.</param>
+        /// <param name="delimiterOptions">Delimiter options to use when matching. If no options provided then the
+        /// default options <see cref="DelimiterOptions.DefaultOptions"/> are used.</param>
         /// <returns>true if a field matches the specified value; otherwise, false.</returns>
-        public bool Matches(string value, bool ignoreCase)
+        public bool Matches(string value, bool ignoreCase, DelimiterOptions delimiterOptions = null)
         {
             if (value == null)
             {
                 throw new ArgumentNullException(nameof(value));
             }
 
-            var parts = value.Split('/');
+            if (!this.Values.Any())
+            {
+                return false;
+            }
+
+            var separators = (delimiterOptions ?? DelimiterOptions.DefaultOptions).NestedFieldDelimiters;
+            var parts = value.Split(separators);
 
             return this.Values.Any(field => field.Matches(parts, ignoreCase));
         }

--- a/src/PartialResponse.Core/ParserContext.cs
+++ b/src/PartialResponse.Core/ParserContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -17,14 +17,21 @@ namespace PartialResponse.Core
         /// Initializes a new instance of the <see cref="ParserContext"/> class.
         /// </summary>
         /// <param name="source">A <see cref="TextReader"/> representing the input string.</param>
-        public ParserContext(TextReader source)
+        /// <param name="options">Delimiters options for parser.</param>
+        public ParserContext(TextReader source, DelimiterOptions options)
         {
             if (source == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
             }
 
             this.Source = source;
+            this.Options = options;
             this.Values = new List<Field>();
         }
 
@@ -38,12 +45,17 @@ namespace PartialResponse.Core
         /// Gets the <see cref="TextReader"/> representing the input string.
         /// </summary>
         /// <returns>The <see cref="TextReader"/> representing the input string.</returns>
-        public TextReader Source { get; private set; }
+        public TextReader Source { get; }
 
         /// <summary>
         /// Gets the values that are extracted while parsing.
         /// </summary>
         /// <returns>The values that are extracted while parsing.</returns>
-        public List<Field> Values { get; private set; }
+        public List<Field> Values { get; }
+
+        /// <summary>
+        /// Gets delimiters options.
+        /// </summary>
+        public DelimiterOptions Options { get; }
     }
 }

--- a/src/PartialResponse.Core/Token.cs
+++ b/src/PartialResponse.Core/Token.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 namespace PartialResponse.Core
 {

--- a/src/PartialResponse.Core/TokenType.cs
+++ b/src/PartialResponse.Core/TokenType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 namespace PartialResponse.Core
 {
@@ -17,24 +17,24 @@ namespace PartialResponse.Core
         Identifier,
 
         /// <summary>
-        /// A forward slash ('/') delimiter.
+        /// A nested field delimiter, for example - forward slash ('/').
         /// </summary>
-        ForwardSlash,
+        NestedFieldDelimiter,
 
         /// <summary>
-        /// An opening parenthesis ('(').
+        /// A nested field group start delimiter, for example - opening parenthesis ('(').
         /// </summary>
-        LeftParenthesis,
+        FieldGroupStartDelimiter,
 
         /// <summary>
-        /// A closing parenthesis (')').
+        /// A nested field group end delimiter, for example - closing parenthesis (')').
         /// </summary>
-        RightParenthesis,
+        FieldGroupEndDelimiter,
 
         /// <summary>
-        /// A comma (',') delimiter.
+        /// A fields delimiter, for example - comma (',').
         /// </summary>
-        Comma,
+        FieldsDelimiter,
 
         /// <summary>
         /// A space, horizontal tab, new line, or carriage return. Typically, a contiguous run of whitespace is a

--- a/src/PartialResponse.Core/TokenType.cs
+++ b/src/PartialResponse.Core/TokenType.cs
@@ -22,12 +22,12 @@ namespace PartialResponse.Core
         NestedFieldDelimiter,
 
         /// <summary>
-        /// A nested field group start delimiter, for example - opening parenthesis ('(').
+        /// A field group start delimiter, for example - opening parenthesis ('(').
         /// </summary>
         FieldGroupStartDelimiter,
 
         /// <summary>
-        /// A nested field group end delimiter, for example - closing parenthesis (')').
+        /// A field group end delimiter, for example - closing parenthesis (')').
         /// </summary>
         FieldGroupEndDelimiter,
 

--- a/src/PartialResponse.Core/Tokenizer.cs
+++ b/src/PartialResponse.Core/Tokenizer.cs
@@ -52,9 +52,7 @@ namespace PartialResponse.Core
                 return new Token(null, TokenType.Eof, this.position);
             }
 
-            var c = this.GetCurrentCharacter();
-
-            if (this.tokensMap.TryGetValue(c, out var tokenType))
+            if (this.tokensMap.TryGetValue(this.GetCurrentCharacter(), out var tokenType))
             {
                 this.TakeCharacter();
 

--- a/src/PartialResponse.Core/UnexpectedTokenError.cs
+++ b/src/PartialResponse.Core/UnexpectedTokenError.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 namespace PartialResponse.Core
 {

--- a/stylecop.json
+++ b/stylecop.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "copyrightText": "Copyright (c) Arjen Post. See LICENSE in the project root for license information.",
+      "copyrightText": "Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.",
       "documentInternalElements": false,
       "xmlHeader": false
     },

--- a/test/PartialResponse.Core.Tests/FieldTests.cs
+++ b/test/PartialResponse.Core.Tests/FieldTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
 using Xunit;
@@ -8,39 +8,34 @@ namespace PartialResponse.Core.Tests
     public class FieldTests
     {
         [Fact]
-        public void TheConstructorShouldThrowIfValueIsNull()
+        public void TheConstructorShouldThrowIfValuesIsNull()
         {
             // Arrange
-            string value = null;
+            string[] value = null;
 
             // Act
             Assert.Throws<ArgumentNullException>(() => new Field(value));
         }
 
         [Fact]
-        public void ThePartsPropertyShouldContainSingleValue()
+        public void TheConstructorShouldThrowIfOneOfValuesIsNull()
         {
             // Arrange
-            var value = "foo";
+            string value = null;
 
             // Act
-            var field = new Field(value);
-
-            // Assert
-            Assert.Equal(new[] { "foo" }, field.Parts);
+            Assert.Throws<ArgumentException>(() => new Field("bla", value));
         }
 
         [Fact]
-        public void ThePartsPropertyShouldContainMultipleValues()
+        public void ThePartsPropertyShouldContainSingleValue()
         {
             // Arrange
-            var value = "foo/bar";
-
             // Act
-            var field = new Field(value);
+            var field = new Field("foo");
 
             // Assert
-            Assert.Equal(new[] { "foo", "bar" }, field.Parts);
+            Assert.Equal(new[] { "foo" }, field.Parts);
         }
 
         [Fact]
@@ -72,7 +67,7 @@ namespace PartialResponse.Core.Tests
         public void TheMatchesMethodShouldReturnFalseForDifferentNestedValues()
         {
             // Arrange
-            var field = new Field("foo/bar");
+            var field = new Field("foo", "bar");
 
             // Act
             var result = field.Matches(new[] { "foo", "baz" });
@@ -111,7 +106,7 @@ namespace PartialResponse.Core.Tests
         public void TheMatchesMethodShouldReturnTrueForOtherSuffixValue()
         {
             // Arrange
-            var field = new Field("foo/bar");
+            var field = new Field("foo", "bar");
 
             // Act
             var result = field.Matches(new[] { "foo" });
@@ -144,20 +139,6 @@ namespace PartialResponse.Core.Tests
 
             // Assert
             Assert.True(result);
-        }
-
-        [Fact]
-        public void TheToStringMethodShouldReturnValue()
-        {
-            // Arrange
-            var value = "foo/bar";
-            var field = new Field(value);
-
-            // Act
-            var result = field.Matches(new[] { "foo" });
-
-            // Assert
-            Assert.Equal(value, field.ToString());
         }
     }
 }

--- a/test/PartialResponse.Core.Tests/FieldsTests.cs
+++ b/test/PartialResponse.Core.Tests/FieldsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
 using Xunit;

--- a/test/PartialResponse.Core.Tests/ParserContextTests.cs
+++ b/test/PartialResponse.Core.Tests/ParserContextTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+﻿// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
 using System.IO;
@@ -15,7 +15,17 @@ namespace PartialResponse.Core.Tests
             TextReader source = null;
 
             // Act
-            Assert.Throws<ArgumentNullException>(() => new ParserContext(source));
+            Assert.Throws<ArgumentNullException>(() => new ParserContext(source, DelimiterOptions.DefaultOptions));
+        }
+
+        [Fact]
+        public void TheConstructorShouldThrowIfDelimiterOptionsIsNull()
+        {
+            // Arrange
+            DelimiterOptions options = null;
+
+            // Act
+            Assert.Throws<ArgumentNullException>(() => new ParserContext(new StringReader(string.Empty), options));
         }
     }
 }

--- a/test/PartialResponse.Core.Tests/ParserTests.cs
+++ b/test/PartialResponse.Core.Tests/ParserTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
 using System.IO;
@@ -24,7 +24,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var source = new StringReader(string.Empty);
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -35,15 +35,18 @@ namespace PartialResponse.Core.Tests
         }
 
         [Theory]
-        [InlineData("/", TokenType.ForwardSlash)]
-        [InlineData("(", TokenType.LeftParenthesis)]
-        [InlineData(")", TokenType.RightParenthesis)]
-        [InlineData(",", TokenType.Comma)]
+        [InlineData("/", TokenType.NestedFieldDelimiter)]
+        [InlineData(".", TokenType.NestedFieldDelimiter)]
+        [InlineData("(", TokenType.FieldGroupStartDelimiter)]
+        [InlineData("[", TokenType.FieldGroupStartDelimiter)]
+        [InlineData(")", TokenType.FieldGroupEndDelimiter)]
+        [InlineData("]", TokenType.FieldGroupEndDelimiter)]
+        [InlineData(",", TokenType.FieldsDelimiter)]
         public void TheParseMethodShouldSetErrorIfIllegalTokenAtStart(string value, TokenType tokenType)
         {
             // Arrange
             var source = new StringReader(value);
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -58,7 +61,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var source = new StringReader("foo");
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -73,7 +76,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var source = new StringReader("foo/bar");
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -84,16 +87,28 @@ namespace PartialResponse.Core.Tests
         }
 
         [Theory]
-        [InlineData("/", TokenType.ForwardSlash)]
-        [InlineData("(", TokenType.LeftParenthesis)]
-        [InlineData(")", TokenType.RightParenthesis)]
-        [InlineData(",", TokenType.Comma)]
-        [InlineData("", TokenType.Eof)]
-        public void TheParseMethodShouldSetErrorIfIllegalTokenAfterForwardSlash(string value, TokenType tokenType)
+        [InlineData(".", "/", TokenType.NestedFieldDelimiter)]
+        [InlineData(".", ".", TokenType.NestedFieldDelimiter)]
+        [InlineData(".", "(", TokenType.FieldGroupStartDelimiter)]
+        [InlineData(".", "[", TokenType.FieldGroupStartDelimiter)]
+        [InlineData(".", ")", TokenType.FieldGroupEndDelimiter)]
+        [InlineData(".", "]", TokenType.FieldGroupEndDelimiter)]
+        [InlineData(".", ",", TokenType.FieldsDelimiter)]
+        [InlineData(".", "", TokenType.Eof)]
+
+        [InlineData("/", "/", TokenType.NestedFieldDelimiter)]
+        [InlineData("/", ".", TokenType.NestedFieldDelimiter)]
+        [InlineData("/", "(", TokenType.FieldGroupStartDelimiter)]
+        [InlineData("/", "[", TokenType.FieldGroupStartDelimiter)]
+        [InlineData("/", ")", TokenType.FieldGroupEndDelimiter)]
+        [InlineData("/", "]", TokenType.FieldGroupEndDelimiter)]
+        [InlineData("/", ",", TokenType.FieldsDelimiter)]
+        [InlineData("/", "", TokenType.Eof)]
+        public void TheParseMethodShouldSetErrorIfIllegalTokenAfterNestedFieldDelimiter(string delimiter, string value, TokenType tokenType)
         {
             // Arrange
-            var source = new StringReader($"foo/{value}");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{delimiter}{value}");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -108,7 +123,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var source = new StringReader("foo,bar");
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -119,16 +134,19 @@ namespace PartialResponse.Core.Tests
         }
 
         [Theory]
-        [InlineData("/", TokenType.ForwardSlash)]
-        [InlineData("(", TokenType.LeftParenthesis)]
-        [InlineData(")", TokenType.RightParenthesis)]
-        [InlineData(",", TokenType.Comma)]
+        [InlineData("/", TokenType.NestedFieldDelimiter)]
+        [InlineData(".", TokenType.NestedFieldDelimiter)]
+        [InlineData("(", TokenType.FieldGroupStartDelimiter)]
+        [InlineData("[", TokenType.FieldGroupStartDelimiter)]
+        [InlineData(")", TokenType.FieldGroupEndDelimiter)]
+        [InlineData("]", TokenType.FieldGroupEndDelimiter)]
+        [InlineData(",", TokenType.FieldsDelimiter)]
         [InlineData("", TokenType.Eof)]
         public void TheParseMethodShouldSetErrorIfIllegalTokenAfterComma(string value, TokenType tokenType)
         {
             // Arrange
             var source = new StringReader($"foo,{value}");
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -138,12 +156,14 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(tokenType, context.Error.Type);
         }
 
-        [Fact]
-        public void TheParseMethodShouldParseGroupedIdentifier()
+        [Theory]
+        [InlineData("(", ")")]
+        [InlineData("[", "]")]
+        public void TheParseMethodShouldParseGroupedIdentifier(string leftGroupDelimiter, string rightGroupDelimiter)
         {
             // Arrange
-            var source = new StringReader("foo(bar)");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{leftGroupDelimiter}bar{rightGroupDelimiter}");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -153,12 +173,14 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(new[] { "foo/bar" }, context.Values.Select(value => string.Join("/", value.Parts)));
         }
 
-        [Fact]
-        public void TheParseMethodShouldParseGroupedMultipleIdentifiers()
+        [Theory]
+        [InlineData("(", ")")]
+        [InlineData("[", "]")]
+        public void TheParseMethodShouldParseGroupedMultipleIdentifiers(string leftGroupDelimiter, string rightGroupDelimiter)
         {
             // Arrange
-            var source = new StringReader("foo(bar,baz)");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{leftGroupDelimiter}bar,baz{rightGroupDelimiter}");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -168,12 +190,14 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(new[] { "foo/bar", "foo/baz" }, context.Values.Select(value => string.Join("/", value.Parts)));
         }
 
-        [Fact]
-        public void TheParseMethodShouldParseIdentifierAfterGroupedMultipleIdentifiers()
+        [Theory]
+        [InlineData("(", ")")]
+        [InlineData("[", "]")]
+        public void TheParseMethodShouldParseIdentifierAfterGroupedMultipleIdentifiers(string leftGroupDelimiter, string rightGroupDelimiter)
         {
             // Arrange
-            var source = new StringReader("foo(bar,baz),qux");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{leftGroupDelimiter}bar,baz{rightGroupDelimiter},qux");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -183,12 +207,16 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(new[] { "foo/bar", "foo/baz", "qux" }, context.Values.Select(value => string.Join("/", value.Parts)));
         }
 
-        [Fact]
-        public void TheParseMethodShouldParseGroupedNestedIdentifier()
+        [Theory]
+        [InlineData("(", ")", "/")]
+        [InlineData("[", "]", "/")]
+        [InlineData("(", ")", ".")]
+        [InlineData("[", "]", ".")]
+        public void TheParseMethodShouldParseGroupedNestedIdentifier(string leftGroupDelimiter, string rightGroupDelimiter, string nestedFieldDelimiter)
         {
             // Arrange
-            var source = new StringReader("foo(bar/baz)");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{leftGroupDelimiter}bar{nestedFieldDelimiter}baz{rightGroupDelimiter}");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -198,12 +226,16 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(new[] { "foo/bar/baz" }, context.Values.Select(value => string.Join("/", value.Parts)));
         }
 
-        [Fact]
-        public void TheParseMethodShouldParseGroupedMultipleNestedIdentifier()
+        [Theory]
+        [InlineData("(", ")", "/")]
+        [InlineData("[", "]", "/")]
+        [InlineData("(", ")", ".")]
+        [InlineData("[", "]", ".")]
+        public void TheParseMethodShouldParseGroupedMultipleNestedIdentifier(string leftGroupDelimiter, string rightGroupDelimiter, string nestedFieldDelimiter)
         {
             // Arrange
-            var source = new StringReader("foo(bar/baz,qux/quux)");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{leftGroupDelimiter}bar{nestedFieldDelimiter}baz,qux{nestedFieldDelimiter}quux{rightGroupDelimiter}");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -213,12 +245,14 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(new[] { "foo/bar/baz", "foo/qux/quux" }, context.Values.Select(value => string.Join("/", value.Parts)));
         }
 
-        [Fact]
-        public void TheParseMethodShouldSetErrorIfTooManyLeftParenthesis()
+        [Theory]
+        [InlineData("(")]
+        [InlineData("[")]
+        public void TheParseMethodShouldSetErrorIfTooManyLeftDelimiters(string leftDelimiter)
         {
             // Arrange
-            var source = new StringReader("foo(bar");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{leftDelimiter}bar");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -228,32 +262,45 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(TokenType.Eof, context.Error.Type);
         }
 
-        [Fact]
-        public void TheParseMethodShouldSetErrorIfTooManyRightParenthesis()
+        [Theory]
+        [InlineData(")")]
+        [InlineData("]")]
+        public void TheParseMethodShouldSetErrorIfTooManyRightDelimiters(string rightDelimiter)
         {
             // Arrange
-            var source = new StringReader("foo(bar))");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo(bar{rightDelimiter}{rightDelimiter}");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
             parser.Parse();
 
             // Assert
-            Assert.Equal(TokenType.RightParenthesis, context.Error.Type);
+            Assert.Equal(TokenType.FieldGroupEndDelimiter, context.Error.Type);
         }
 
         [Theory]
-        [InlineData("/", TokenType.ForwardSlash)]
-        [InlineData("(", TokenType.LeftParenthesis)]
-        [InlineData(")", TokenType.RightParenthesis)]
-        [InlineData(",", TokenType.Comma)]
-        [InlineData("", TokenType.Eof)]
-        public void TheParseMethodShouldSetErrorIfIllegalTokenAfterLeftParenthesis(string value, TokenType tokenType)
+        [InlineData("(", "/", TokenType.NestedFieldDelimiter)]
+        [InlineData("(", ".", TokenType.NestedFieldDelimiter)]
+        [InlineData("(", "(", TokenType.FieldGroupStartDelimiter)]
+        [InlineData("(", "[", TokenType.FieldGroupStartDelimiter)]
+        [InlineData("(", ")", TokenType.FieldGroupEndDelimiter)]
+        [InlineData("(", "]", TokenType.FieldGroupEndDelimiter)]
+        [InlineData("(", ",", TokenType.FieldsDelimiter)]
+        [InlineData("(", "", TokenType.Eof)]
+        [InlineData("[", "/", TokenType.NestedFieldDelimiter)]
+        [InlineData("[", ".", TokenType.NestedFieldDelimiter)]
+        [InlineData("[", "(", TokenType.FieldGroupStartDelimiter)]
+        [InlineData("[", "[", TokenType.FieldGroupStartDelimiter)]
+        [InlineData("[", ")", TokenType.FieldGroupEndDelimiter)]
+        [InlineData("[", "]", TokenType.FieldGroupEndDelimiter)]
+        [InlineData("[", ",", TokenType.FieldsDelimiter)]
+        [InlineData("[", "", TokenType.Eof)]
+        public void TheParseMethodShouldSetErrorIfIllegalTokenAfterLeftGroupDelimiter(string delimiter, string value, TokenType tokenType)
         {
             // Arrange
-            var source = new StringReader($"foo({value}");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{delimiter}{value}");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -264,13 +311,13 @@ namespace PartialResponse.Core.Tests
         }
 
         [Theory]
-        [InlineData("/", TokenType.ForwardSlash)]
-        [InlineData("(", TokenType.LeftParenthesis)]
-        public void TheParseMethodShouldSetErrorIfIllegalTokenAfterRightParenthesis(string value, TokenType tokenType)
+        [InlineData(")", "/", TokenType.NestedFieldDelimiter)]
+        [InlineData("]", "(", TokenType.FieldGroupStartDelimiter)]
+        public void TheParseMethodShouldSetErrorIfIllegalTokenAfterRightGroupDelimiter(string delimiter, string value, TokenType tokenType)
         {
             // Arrange
-            var source = new StringReader($"foo(bar){value}");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo(bar{delimiter}{value}");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -280,12 +327,14 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(tokenType, context.Error.Type);
         }
 
-        [Fact]
-        public void TheParseMethodShouldParseIdentifierAfterGroupedIdentifier()
+        [Theory]
+        [InlineData("(", ")")]
+        [InlineData("[", "]")]
+        public void TheParseMethodShouldParseIdentifierAfterGroupedIdentifier(string left, string right)
         {
             // Arrange
-            var source = new StringReader("foo(bar),baz");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{left}bar{right},baz");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -295,12 +344,14 @@ namespace PartialResponse.Core.Tests
             Assert.Equal(new[] { "foo/bar", "baz" }, context.Values.Select(value => string.Join("/", value.Parts)));
         }
 
-        [Fact]
-        public void TheParseMethodShouldParseIdentifierAfterNestedGroupedIdentifiers()
+        [Theory]
+        [InlineData("(", ")")]
+        [InlineData("[", "]")]
+        public void TheParseMethodShouldParseIdentifierAfterNestedGroupedIdentifiers(string left, string right)
         {
             // Arrange
-            var source = new StringReader("foo(bar(baz)),qux");
-            var context = new ParserContext(source);
+            var source = new StringReader($"foo{left}bar{left}baz{right}{right},qux");
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -315,7 +366,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var source = new StringReader(" foo");
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -330,7 +381,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var source = new StringReader("\tfoo");
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -345,7 +396,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var source = new StringReader("\rfoo");
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act
@@ -360,7 +411,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var source = new StringReader("\nfoo");
-            var context = new ParserContext(source);
+            var context = new ParserContext(source, DelimiterOptions.DefaultOptions);
             var parser = new Parser(context);
 
             // Act

--- a/test/PartialResponse.Core.Tests/TokenTests.cs
+++ b/test/PartialResponse.Core.Tests/TokenTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
 using Xunit;

--- a/test/PartialResponse.Core.Tests/TokenizerTests.cs
+++ b/test/PartialResponse.Core.Tests/TokenizerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using System;
 using System.IO;
@@ -11,122 +11,82 @@ namespace PartialResponse.Core.Tests
         [Fact]
         public void TheConstructorShouldThrowIfReaderIsNull()
         {
-            // Arrange
-            TextReader reader = null;
-
             // Act
-            Assert.Throws<ArgumentNullException>("source", () => new Tokenizer(reader));
+            Assert.Throws<ArgumentNullException>("source", () => new Tokenizer(null, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap));
         }
 
         [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeForwardSlash()
+        public void TheConstructorShouldThrowIfDelimiterMapIsNull()
+        {
+            // Act
+            Assert.Throws<ArgumentNullException>("tokensMap", () => new Tokenizer(new StringReader(string.Empty), null));
+        }
+
+        [Theory]
+        [InlineData("/")]
+        [InlineData(".")]
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueNestedFieldDelimiter(string data)
         {
             // Arrange
-            var reader = new StringReader("/");
-            var tokenizer = new Tokenizer(reader);
+            var reader = new StringReader(data);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             // Act
             var token = tokenizer.NextToken();
 
             // Assert
-            Assert.Equal(TokenType.ForwardSlash, token.Type);
+            Assert.Equal(TokenType.NestedFieldDelimiter, token.Type);
+            Assert.Equal(data, token.Value);
         }
 
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueForwardSlash()
+        [Theory]
+        [InlineData("(")]
+        [InlineData("[")]
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueStartGroupDelimiter(string data)
         {
             // Arrange
-            var reader = new StringReader("/");
-            var tokenizer = new Tokenizer(reader);
+            var reader = new StringReader(data);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             // Act
             var token = tokenizer.NextToken();
 
             // Assert
-            Assert.Equal("/", token.Value);
+            Assert.Equal(TokenType.FieldGroupStartDelimiter, token.Type);
+
+            Assert.Equal(data, token.Value);
         }
 
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeLeftParenthesis()
+        [Theory]
+        [InlineData(")")]
+        [InlineData("]")]
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueEndGroupDelimiter(string data)
         {
             // Arrange
-            var reader = new StringReader("(");
-            var tokenizer = new Tokenizer(reader);
+            var reader = new StringReader(data);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             // Act
             var token = tokenizer.NextToken();
 
             // Assert
-            Assert.Equal(TokenType.LeftParenthesis, token.Type);
+            Assert.Equal(TokenType.FieldGroupEndDelimiter, token.Type);
+
+            Assert.Equal(data, token.Value);
         }
 
         [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueLeftParenthesis()
-        {
-            // Arrange
-            var reader = new StringReader("(");
-            var tokenizer = new Tokenizer(reader);
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
-            Assert.Equal("(", token.Value);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeRightParenthesis()
-        {
-            // Arrange
-            var reader = new StringReader(")");
-            var tokenizer = new Tokenizer(reader);
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
-            Assert.Equal(TokenType.RightParenthesis, token.Type);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueRightParenthesis()
-        {
-            // Arrange
-            var reader = new StringReader(")");
-            var tokenizer = new Tokenizer(reader);
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
-            Assert.Equal(")", token.Value);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeComma()
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueFieldsDelimiter()
         {
             // Arrange
             var reader = new StringReader(",");
-            var tokenizer = new Tokenizer(reader);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             // Act
             var token = tokenizer.NextToken();
 
             // Assert
-            Assert.Equal(TokenType.Comma, token.Type);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueComma()
-        {
-            // Arrange
-            var reader = new StringReader(",");
-            var tokenizer = new Tokenizer(reader);
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
+            Assert.Equal(TokenType.FieldsDelimiter, token.Type);
             Assert.Equal(",", token.Value);
         }
 
@@ -135,62 +95,32 @@ namespace PartialResponse.Core.Tests
         [InlineData("\t")]
         [InlineData("\r")]
         [InlineData("\n")]
-        public void TheNextTokenMethodShouldReturnTokenTypeWhiteSpace(string value)
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueWhiteSpace(string value)
         {
             // Arrange
             var reader = new StringReader(value);
-            var tokenizer = new Tokenizer(reader);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             // Act
             var token = tokenizer.NextToken();
 
             // Assert
             Assert.Equal(TokenType.WhiteSpace, token.Type);
-        }
-
-        [Theory]
-        [InlineData(" ")]
-        [InlineData("\t")]
-        [InlineData("\r")]
-        [InlineData("\n")]
-        public void TheNextTokenMethodShouldReturnTokenValueWhiteSpace(string value)
-        {
-            // Arrange
-            var reader = new StringReader(value);
-            var tokenizer = new Tokenizer(reader);
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
             Assert.Equal(value, token.Value);
         }
 
         [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeIdentifier()
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueIdentifier()
         {
             // Arrange
             var reader = new StringReader("foo");
-            var tokenizer = new Tokenizer(reader);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             // Act
             var token = tokenizer.NextToken();
 
             // Assert
             Assert.Equal(TokenType.Identifier, token.Type);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueIdentifier()
-        {
-            // Arrange
-            var reader = new StringReader("foo");
-            var tokenizer = new Tokenizer(reader);
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
             Assert.Equal("foo", token.Value);
         }
 
@@ -199,7 +129,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var reader = new StringReader("foo");
-            var tokenizer = new Tokenizer(reader);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             tokenizer.NextToken();
 
@@ -211,55 +141,28 @@ namespace PartialResponse.Core.Tests
         }
 
         [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueIdentifierBeforeForwardSlash()
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueIdentifierBeforeForwardSlash()
         {
             // Arrange
             var reader = new StringReader("foo/");
-            var tokenizer = new Tokenizer(reader);
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
-            Assert.Equal("foo", token.Value);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeIdentifierBeforeForwardSlash()
-        {
-            // Arrange
-            var reader = new StringReader("foo/");
-            var tokenizer = new Tokenizer(reader);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             // Act
             var token = tokenizer.NextToken();
 
             // Assert
             Assert.Equal(TokenType.Identifier, token.Type);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueIdentifierAfterForwardSlash()
-        {
-            // Arrange
-            var reader = new StringReader("/foo");
-            var tokenizer = new Tokenizer(reader);
-
-            tokenizer.NextToken();
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
             Assert.Equal("foo", token.Value);
         }
 
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeIdentifierAfterForwardSlash()
+        [Theory]
+        [InlineData("/")]
+        [InlineData(".")]
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueIdentifierAfterNestedFieldDelimiter(string delimiter)
         {
             // Arrange
-            var reader = new StringReader("/foo");
-            var tokenizer = new Tokenizer(reader);
+            var reader = new StringReader($"{delimiter}foo");
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             tokenizer.NextToken();
 
@@ -268,58 +171,30 @@ namespace PartialResponse.Core.Tests
 
             // Assert
             Assert.Equal(TokenType.Identifier, token.Type);
+            Assert.Equal("foo", token.Value);
         }
 
         [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueIdentifierBeforeWhiteSpace()
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueIdentifierBeforeWhiteSpace()
         {
             // Arrange
             var reader = new StringReader("foo ");
-            var tokenizer = new Tokenizer(reader);
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
-            Assert.Equal("foo", token.Value);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeIdentifierBeforeWhiteSpace()
-        {
-            // Arrange
-            var reader = new StringReader("foo ");
-            var tokenizer = new Tokenizer(reader);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             // Act
             var token = tokenizer.NextToken();
 
             // Assert
             Assert.Equal(TokenType.Identifier, token.Type);
-        }
-
-        [Fact]
-        public void TheNextTokenMethodShouldReturnTokenValueIdentifierAfterWhiteSpace()
-        {
-            // Arrange
-            var reader = new StringReader(" foo");
-            var tokenizer = new Tokenizer(reader);
-
-            tokenizer.NextToken();
-
-            // Act
-            var token = tokenizer.NextToken();
-
-            // Assert
             Assert.Equal("foo", token.Value);
         }
 
         [Fact]
-        public void TheNextTokenMethodShouldReturnTokenTypeIdentifierAfterWhiteSpace()
+        public void TheNextTokenMethodShouldReturnTokenTypeAndValueIdentifierAfterWhiteSpace()
         {
             // Arrange
             var reader = new StringReader(" foo");
-            var tokenizer = new Tokenizer(reader);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             tokenizer.NextToken();
 
@@ -328,6 +203,7 @@ namespace PartialResponse.Core.Tests
 
             // Assert
             Assert.Equal(TokenType.Identifier, token.Type);
+            Assert.Equal("foo", token.Value);
         }
 
         [Fact]
@@ -335,7 +211,7 @@ namespace PartialResponse.Core.Tests
         {
             // Arrange
             var reader = new StringReader("foo/");
-            var tokenizer = new Tokenizer(reader);
+            var tokenizer = new Tokenizer(reader, DelimiterOptions.DefaultOptions.DelimiterToTokenTypeMap);
 
             tokenizer.NextToken();
 

--- a/test/PartialResponse.Core.Tests/UnexpectedTokenErrorTests.cs
+++ b/test/PartialResponse.Core.Tests/UnexpectedTokenErrorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Arjen Post. See LICENSE in the project root for license information.
+// Copyright (c) Arjen Post and contributors. See LICENSE in the project root for license information.
 
 using Xunit;
 


### PR DESCRIPTION
Implemented support of delimiter options so that delimiters can be configurable (delimiters still limited to be chars). This should fix https://github.com/dotarj/PartialResponse/issues/23 